### PR TITLE
Initialize TMS monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.turbo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# ticket
+# KTern.AI Ticket Management System (TMS)
+
+This repository contains a monorepo setup for KTern.AI's Ticket Management System. The project is structured using **Turborepo** and includes a Next.js frontend and a Nest.js backend. Shared packages provide UI components, configuration, libraries, utilities and global TypeScript types.
+
+```
+├── apps
+│   ├── frontend (Next.js)
+│   └── backend (Nest.js)
+├── packages
+│   ├── ui
+│   ├── config
+│   ├── lib
+│   ├── utils
+│   └── types
+├── prisma
+├── redis
+├── workflows
+├── tests
+└── docs
+```
+
+The application follows SOLID principles, 12‑factor methodology and leverages design patterns such as Factory, Singleton, Adapter and Observer. See the documentation under `docs/` for more details.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,5 @@
+# Backend (Nest.js)
+- RESTful API design with Prisma ORM (MongoDB Atlas)
+- BullMQ job queues for SLA and notification processing
+- Redis caching for ticket listing and SLA countdown
+- Integrated with Azure DevOps for product backlog sync

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "backend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "build": "nest build",
+    "lint": "eslint . --ext .ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.5.0"
+  }
+}

--- a/apps/backend/src/controller.ts
+++ b/apps/backend/src/controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello() {
+    return this.appService.getHello();
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/backend/src/module.ts
+++ b/apps/backend/src/module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './controller';
+import { AppService } from './service';
+
+@Module({
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/apps/backend/src/service.ts
+++ b/apps/backend/src/service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello() {
+    return { message: 'KTern.AI Ticket Management System API' };
+  }
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,0 +1,5 @@
+# Frontend (Next.js)
+- Next.js App Router based application
+- Uses Auth.js for authentication
+- Styled using Geist, Tailwind CSS, ShadCN, Tremor.so
+- Monorepo managed via Turborepo

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -1,0 +1,3 @@
+body {
+  font-family: Geist, sans-serif;
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,0 +1,9 @@
+import './globals.css';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>KTern.AI Ticket Management System</div>;
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Project Documentation
+- API Contracts using OpenAPI
+- System Architecture Diagrams
+- OOP Design Patterns applied in both frontend and backend

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,34 @@
+# API Contracts
+
+```yaml
+paths:
+  /api/tickets:
+    get:
+      summary: List all tickets
+      responses:
+        '200':
+          description: Array of tickets
+    post:
+      summary: Create a new ticket
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Ticket'
+      responses:
+        '201':
+          description: Ticket created
+  /api/tickets/{id}:
+    get:
+      summary: Get ticket by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ticket details
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,3 @@
+# System Architecture
+
+The system is divided into a Next.js frontend and a Nest.js backend. Both applications share common packages and follow SOLID principles and 12 factor app methodology. Redis and BullMQ provide caching and job queues, while MongoDB is accessed via Prisma.

--- a/docs/folder-ownership.md
+++ b/docs/folder-ownership.md
@@ -1,0 +1,11 @@
+# Folder Ownership
+
+| Folder | Owner |
+| --- | --- |
+| apps/frontend | Frontend Engineers |
+| apps/backend | Backend Engineers |
+| packages/ui | Design System Team |
+| packages/lib | Shared Developers |
+| prisma | Backend Engineers |
+| redis | Backend Engineers |
+| docs | Architect |

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,9 @@
+# OOP Design Patterns
+
+- **Factory**: ticket, SLA and notification service creators.
+- **Singleton**: Database and Redis connections.
+- **Adapter**: Azure DevOps integration layer.
+- **Decorator**: Ticket service layering SLA observers.
+- **Observer**: Notification for SLA escalation.
+- **Strategy**: SLA calculation and priority routing.
+- **Command**: Queue jobs and timers.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ticket-monorepo",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo run test"
+  },
+  "devDependencies": {
+    "turbo": "^1.10.7"
+  }
+}

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,3 @@
+# Configuration Package
+- Environment variable and Prisma configuration
+- Shared configuration utilities for apps

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -1,0 +1,4 @@
+# Shared Libraries
+- Prisma, Redis, Auth.js clients
+- BullMQ and Novu clients
+- Common library code used across apps

--- a/packages/lib/cache.ts
+++ b/packages/lib/cache.ts
@@ -1,0 +1,10 @@
+import redisClient from './redis';
+
+export async function getOrSetCache<T>(key: string, fetchFn: () => Promise<T>, ttl = 300): Promise<T> {
+  const cached = await redisClient.get(key);
+  if (cached) return JSON.parse(cached);
+
+  const fresh = await fetchFn();
+  await redisClient.set(key, JSON.stringify(fresh), 'EX', ttl);
+  return fresh;
+}

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './redis';
+export * from './cache';
+export * from './novu';

--- a/packages/lib/novu.ts
+++ b/packages/lib/novu.ts
@@ -1,0 +1,18 @@
+import { Novu } from '@novu/node';
+
+export const novu = new Novu(process.env.NOVU_API_KEY || '');
+
+export async function sendNotification({
+  to,
+  templateId,
+  payload,
+}: {
+  to: string;
+  templateId: string;
+  payload: object;
+}) {
+  await novu.trigger(templateId, {
+    to: { subscriberId: to },
+    payload,
+  });
+}

--- a/packages/lib/redis.ts
+++ b/packages/lib/redis.ts
@@ -1,0 +1,5 @@
+import Redis from 'ioredis';
+
+const redisClient = new Redis(process.env.REDIS_URL || '');
+
+export default redisClient;

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,2 @@
+# Global TypeScript Types
+- Shared type definitions used in both frontend and backend

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,5 @@
+# Shared UI Components
+- Atoms: Buttons, Inputs
+- Molecules: Ticket Cards, SLA Badges
+- Organisms: Ticket Tables, Dashboard Graphs
+- Fully styled using Tailwind CSS + ShadCN + Tremor.so

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,2 @@
+# Utility Helpers
+- Common helper functions used across the monorepo

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,4 @@
+# Prisma ORM
+- MongoDB schema definitions
+- Prisma migration scripts
+- Centralized DB schema for ticket management system

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,71 @@
+// Prisma schema for MongoDB
+ datasource db {
+   provider = "mongodb"
+   url      = env("DATABASE_URL")
+ }
+
+ generator client {
+   provider = "prisma-client-js"
+ }
+
+ model User {
+   id       String   @id @default(auto()) @map("_id")
+   name     String
+   email    String   @unique
+   role     String
+   tickets  Ticket[]
+ }
+
+ model Ticket {
+   id            String   @id @default(auto()) @map("_id")
+   title         String
+   description   String
+   type          String
+   priority      String
+   status        String
+   slaId         String
+   assignedToId  String?
+   createdById   String
+   createdAt     DateTime @default(now())
+   updatedAt     DateTime @updatedAt
+   comments      Comment[]
+ }
+
+ model Comment {
+   id         String   @id @default(auto()) @map("_id")
+   ticketId   String
+   authorId   String
+   body       String
+   createdAt  DateTime @default(now())
+ }
+
+ model SLA {
+   id             String   @id @default(auto()) @map("_id")
+   ticketType     String
+   responseTime   Int
+   resolutionTime Int
+ }
+
+ model FeatureRequest {
+   id          String   @id @default(auto()) @map("_id")
+   title       String
+   description String
+   votes       Int      @default(0)
+   status      String
+   createdAt   DateTime @default(now())
+ }
+
+ model RoadmapItem {
+   id            String   @id @default(auto()) @map("_id")
+   title         String
+   status        String
+   linkedFeatures String[]
+ }
+
+ model ReleaseNote {
+   id            String   @id @default(auto()) @map("_id")
+   version       String
+   description   String
+   linkedTickets String[]
+   createdAt     DateTime @default(now())
+ }

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,0 +1,5 @@
+# Redis Queues & Jobs
+- SLA monitoring (sla-monitor)
+- Ticket update batch notifications
+- Automated reporting queue
+- Azure DevOps ticket synchronization jobs

--- a/redis/workers/sla-monitor.ts
+++ b/redis/workers/sla-monitor.ts
@@ -1,0 +1,18 @@
+import { Queue, Worker } from 'bullmq';
+import redisClient from '../../packages/lib/redis';
+
+const slaQueue = new Queue('sla-monitor', { connection: redisClient });
+
+const slaWorker = new Worker(
+  'sla-monitor',
+  async job => {
+    const { ticketId, deadline } = job.data;
+    const now = new Date();
+    if (now > new Date(deadline)) {
+      console.log(`SLA Breach for ticket ${ticketId}`);
+    }
+  },
+  { connection: redisClient }
+);
+
+export { slaQueue, slaWorker };

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -1,0 +1,2 @@
+# Playwright Tests
+End-to-end automation tests for the frontend

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,2 @@
+# Unit Tests
+Backend unit tests for services and controllers

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "apps/frontend"},
+    {"path": "apps/backend"}
+  ]
+}

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,2 @@
+# n8n Workflows
+Automation workflows for ticket routing, SLA breach notifications and reminders.

--- a/workflows/sla-breach.json
+++ b/workflows/sla-breach.json
@@ -1,0 +1,7 @@
+{
+  "name": "SLA Breach Notification",
+  "nodes": [
+    {"parameters": {}, "name": "Start", "type": "n8n-nodes-base.start"},
+    {"parameters": {"subscriberId": "={{$json.ticketId}}"}, "name": "Novu", "type": "novu"}
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js and Nest.js apps in a turborepo
- add shared packages (config, lib, utils, types, ui)
- include Redis worker and Novu notification client
- document API contracts, architecture and folder ownership
- provide Prisma schema for MongoDB models

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685c51b085e8832d912f26685ec3a469